### PR TITLE
bugfix/horizontal-navigation-cut

### DIFF
--- a/src/scss/layout/_navigation.scss
+++ b/src/scss/layout/_navigation.scss
@@ -1,6 +1,6 @@
 .nav {
   &__button-menu {
-    border-radius: 39px;
+    border-radius: 40px;
     bottom: 20px;
     box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.11);
     position: fixed;
@@ -18,13 +18,17 @@
     display: block;
     height: 100vh;
     left: 0;
+    overflow-y: scroll;
     padding: 210px 20px 20px;
     position: fixed;
-    transition: transform 0.15s linear;
+    transition: bottom 0.15s linear;
     width: 100%;
 
     &--active {
-      transform: translateY(-100%);
+      bottom: 0;
+      .nav__button-close {
+        display: block;
+      }
     }
   }
 
@@ -53,7 +57,8 @@
 
   &__button-close {
     bottom: 20px;
-    position: absolute;
+    position: fixed;
+    display: none;
     right: 20px;
     width: 60px;
   }


### PR DESCRIPTION
**DESCRIPTION OF THE FIX:** Add scroll to navigation in horizontal view

1. Trello task: https://trello.com/c/cih5bGtG/39-mobile-menu-flotante-bug-corte-en-vista-horizontal
2. Zeplin task: https://app.zeplin.io/project/5f15bfe784a1689e60712353/screen/5f28bee24633762fd1800153
3. Video that show up the final behavior
![Video](https://user-images.githubusercontent.com/6738269/90992732-3b7ae480-e577-11ea-8f3c-5415ef74157a.gif)

NOTE
It was necessary to replace the property "Transform" in the navigation's animation for the property "position" instead because the "fixed" value used in close button "nav__button-close" has no effect when it's father container has applied the property transform.