### PR TITLE
feature/page-title-desktop

### DIFF
--- a/src/js/components/pageTitle.js
+++ b/src/js/components/pageTitle.js
@@ -1,16 +1,10 @@
+import { newText, newContainer } from '../helpers/helpers';
+
 const pageTitle = (data) => {
-  const section = document.createElement('section');
-  const eyebrow = document.createElement('p');
-  const heading = document.createElement('h1');
-
-  section.classList.add('page-title');
-  eyebrow.innerText = data.eyebrow;
-  eyebrow.classList.add('text', 'text-normal', 'page-title__eyebrow');
-  heading.innerText = data.heading;
-  heading.classList.add('heading', 'heading-1', 'page-title__heading');
-
-  section.appendChild(eyebrow);
-  section.appendChild(heading);
+  const eyebrow = newText('p', data.eyebrow, ['text', 'text-normal', 'page-title__eyebrow']);
+  const heading = newText('h1', data.heading, ['heading', 'heading-1', 'page-title__heading']);
+  const wrapper = newContainer('div', [eyebrow, heading], ['container']);
+  const section = newContainer('section', [wrapper], ['page-title']);
 
   return section;
 };

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -26,6 +26,11 @@
   &-1 {
     font-size: 40px;
     line-height: 1.25;
+
+    @include viewport-desktop {
+      font-size: 120px;
+      line-height: 1;
+    }
   }
 
   &-2 {

--- a/src/scss/components/_page-title.scss
+++ b/src/scss/components/_page-title.scss
@@ -1,6 +1,7 @@
 .page-title {
   background-color: $green;
-  padding: 20px 39px 34px 32px;
+  margin-top: 89px;
+  padding: 20px 0 34px;
 
   &__eyebrow {
     color: $white;
@@ -10,5 +11,20 @@
 
   &__heading {
     color: $white;
+  }
+
+  @include viewport-desktop {
+    background-color: $white;
+    margin-bottom: 40px;
+    margin-top: 260px;
+    padding: 0;
+
+    &__eyebrow {
+      display: none;
+    }
+
+    &__heading {
+      color: $blue-grey-dark;
+    }
   }
 }


### PR DESCRIPTION
Link Trello: https://trello.com/c/lln2uH59/47-desktop-t%C3%ADtulo-de-p%C3%A1gina-p%C3%A1ginas-de-contenido-3
Link Zeplin: https://app.zeplin.io/project/5f15bfe784a1689e60712353/screen/5f316d6ad0299b1c22b4b74c

- Add a desktop design to page title component
- Add desktop style for heading typography 
- Refactor page title component to use the helper's functions 

![image](https://user-images.githubusercontent.com/58575993/92434285-0ec4f080-f165-11ea-8333-e15c65440533.png)
